### PR TITLE
#7 Fix cleanup rollback after unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 Codeception extension Change Log
 2.0.5 under development
 -----------------------
 
+- Bug #7: Extension won't create new app instance if it already exists, for example was created in module (kaiserfedor)
 
 
 2.0.4 May 10, 2015

--- a/TestCase.php
+++ b/TestCase.php
@@ -104,6 +104,9 @@ class TestCase extends Test
      */
     protected function mockApplication($config = null)
     {
+        if (isset(Yii::$app)) {
+            return;
+        }
         Yii::$container = new Container();
         $config = $config === null ? $this->appConfig : $config;
         if (is_string($config)) {


### PR DESCRIPTION
Method TestCase::mockApplication() checks existence of application in stance and won't create new instance if it already exists. It solved problem that transaction for rollback and test use the same db connection.
